### PR TITLE
temporary fix to work around nasa CMR issues

### DIFF
--- a/00_Introduction_Setup/test_netrc.py
+++ b/00_Introduction_Setup/test_netrc.py
@@ -15,16 +15,17 @@ osgeo.gdal.SetConfigOption('CPL_VSIL_CURL_ALLOWED_EXTENSIONS','TIF, TIFF')
 # Define AOI (Area-Of-Interest) & time-window
 livingston_tx, delta = (-95.09, 30.69), 0.1
 AOI = tuple(coord + sgn*delta for sgn in (-1,+1) for coord in livingston_tx)
-start, stop = '2024-04-30', '2024-05-31'
+start, stop = '2024-04-30', '2024-05-05'
 WINDOW = f'{start}/{stop}'
 
 # Prepare PySTAC client
-STAC_URL, COLLECTIONS = 'https://cmr.earthdata.nasa.gov/stac', ["OPERA_L3_DSWX-HLS_V1"]
+STAC_URL, COLLECTIONS = 'https://cmr.earthdata.nasa.gov/stac', ["OPERA_L3_DSWX-HLS_V1_1.0"]
 catalog = Client.open(f'{STAC_URL}/POCLOUD/')
 
 print("Testing PySTAC search...")
 opts = dict(bbox=AOI, collections=COLLECTIONS, datetime=WINDOW)
 results = list(catalog.search(**opts).items_as_dicts())
+print(len(results))
 test_uri = results[0]['assets']['0_B01_WTR']['href']
 
 try:


### PR DESCRIPTION
The powers that be have changed the collection names for the OPERA DSWx-HLS data product, which is reflected here. This change needs to propagate to all other scripts/notebooks that use this data product. In a similar vein, the OPERA DIST-ALERT data product also has a new collection name - `OPERA_L3_DIST-ALERT-HLS_V1_1` which needs to be applied where it gets used.

Secondly, something is currently broken with NASA CMR and any search results returning more than 20 items result in the API breaking (see [here](https://forum.earthdata.nasa.gov/viewtopic.php?t=5922&sid=353377393ac757496463beaceb408d67)). The trivial solution to this is to reduce the time window over which we search, or to add a `limit` qualifier to the search query. I have opted for the former here, since this script is only meant to test if users are able to access NASA earthdata products succesfully.